### PR TITLE
Remove output collection when destroying machine

### DIFF
--- a/Blueprint/Assets/Scripts/Model/Reducer/MachineReducer.cs
+++ b/Blueprint/Assets/Scripts/Model/Reducer/MachineReducer.cs
@@ -43,11 +43,6 @@ namespace Model.Reducer {
                 GameManager.Instance().inventoryStore.Dispatch(new AddItemToInventory(item.GetId(), item.GetQuantity(), item.GetName()));
             }
 
-            if (machine.output.IsPresent()) {
-                InventoryItem item = machine.output.Get();
-                GameManager.Instance().inventoryStore.Dispatch(new AddItemToInventory(item.GetId(), item.GetQuantity(), item.GetName()));
-            }
-
             state.grid.Remove(removeMachine.machineLocation);
         }
 


### PR DESCRIPTION
- Removes collection of output item when destroying a machine (you could actually get *free* resources with this 😨)

Fixes #76