### PR TITLE
Fix gate UI look and move issue

### DIFF
--- a/Blueprint/Assets/HolyShift/Scripts.meta
+++ b/Blueprint/Assets/HolyShift/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c40fc1454b2e4d5490c4df7d695a4f0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Blueprint/Assets/Scripts/Controller/MenuController.cs
+++ b/Blueprint/Assets/Scripts/Controller/MenuController.cs
@@ -31,6 +31,9 @@ namespace Controller {
         private Image cursor;
         private SVGImage rmb;
         private const int rightButton = 1;
+        private PlayerMoveController movement;
+        private PlayerLookController looking;
+
 
         void Start() {
             inventoryCanvas = GameObject.FindGameObjectWithTag("Inventory").GetComponent<Canvas>();
@@ -48,6 +51,8 @@ namespace Controller {
             machineInventoryCanvas = GameObject.FindGameObjectWithTag("MachineInventory").GetComponent<Canvas>();
             cursor = GameObject.Find("Cursor Image").GetComponent<Image>();
             rmb = GameObject.Find("RMB Image").GetComponent<SVGImage>();
+            movement = GameObject.Find("Player").GetComponent<PlayerMoveController>();
+            looking = GameObject.Find("PlayerCamera").GetComponent<PlayerLookController>();
 
             inventoryCanvas.enabled = false;
             blueprintCanvas.enabled = false;
@@ -114,8 +119,8 @@ namespace Controller {
             heldCanvas.enabled = false;
             cursorCanvas.enabled = false;
             pauseCanvas.enabled = false;
-            GameObject.Find("Player").GetComponent<PlayerMoveController>().enabled = false;
-            GameObject.Find("PlayerCamera").GetComponent<PlayerLookController>().enabled = false;
+            movement.enabled = false;
+            looking.enabled = false;
             Invoke("ToMainMenu", 30.0f);
         }
 
@@ -185,6 +190,7 @@ namespace Controller {
 
         private void OpenGate() {
             gateCanvas.enabled = true;
+            Time.timeScale = 0;
         }
 
         // Playing state
@@ -245,6 +251,7 @@ namespace Controller {
         }
 
         private void EnableMouse() {
+            Time.timeScale = 1;
             gateCanvas.enabled = false;
             cursor.enabled = false;
             rmb.enabled = true;

--- a/Blueprint/ProjectSettings/ProjectVersion.txt
+++ b/Blueprint/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.0f2
+m_EditorVersion: 2018.3.2f1


### PR DESCRIPTION
This addresses the issue where you could look around in the gate ui menu. Now it should pause and you won't be able to do anything until you click the esc key.

Closes #83 