### PR TITLE
Fix issue where the camera jumps on exiting UI

### DIFF
--- a/Blueprint/Assets/Scripts/Controller/MenuController.cs
+++ b/Blueprint/Assets/Scripts/Controller/MenuController.cs
@@ -297,8 +297,8 @@ namespace Controller {
             Cursor.visible = true;
             cursorCanvas.enabled = false;
             heldCanvas.enabled = false;
-            looking.enabled = true;
-            movement.enabled = true;
+            looking.enabled = false;
+            movement.enabled = false;
         }
 
         public void StateDidUpdate(UIState state) {


### PR DESCRIPTION
As above.

Test by opening a UI, moving the mouse off-centre, closing the UI. The camera should no longer jump to a different direction