### PR TITLE
Require wires between solar and machines

### DIFF
--- a/Blueprint/Assets/Editor/WireTests.cs
+++ b/Blueprint/Assets/Editor/WireTests.cs
@@ -50,7 +50,7 @@ namespace Tests {
             GameManager.Instance().mapStore.Dispatch(new PlaceItem(machineLocation, 26)); 
             GameManager.Instance().mapStore.Dispatch(new PlaceItem(solarLocation, 25));
 
-            Assert.True(GameManager.Instance().machineStore.GetState().grid[machineLocation].HasFuel());
+            Assert.False(GameManager.Instance().machineStore.GetState().grid[machineLocation].HasFuel());
         }
 
         [Test]

--- a/Blueprint/Assets/Scripts/Model/Reducer/MachineReducer.cs
+++ b/Blueprint/Assets/Scripts/Model/Reducer/MachineReducer.cs
@@ -177,7 +177,7 @@ namespace Model.Reducer {
         }
 
 
-        private bool isConnected(Vector2 location) {
+        private bool isConnected(Vector2 location, int depth = 0) {
             consideredConnected.Add(location);
             bool connected = false;
             foreach (Vector2 neighbour in location.HexNeighbours()) {
@@ -190,12 +190,16 @@ namespace Model.Reducer {
 
                 // If is a solar panel
                 if (neighbourID == 25) {
-                    return true;
-                } 
+                    if (depth > 0) {
+                        return true;
+                    }
+                    // If 0 depth, allow to be considered again
+                    consideredConnected.Remove(neighbour);
+                }
                 
                 // If is a wire 
                 if (neighbourID == 22) {
-                    connected = connected || isConnected(neighbour);
+                    connected = connected || isConnected(neighbour, depth + 1);
                 }
             }
 

--- a/Blueprint/Assets/Scripts/Model/Reducer/MapReducer.cs
+++ b/Blueprint/Assets/Scripts/Model/Reducer/MapReducer.cs
@@ -45,6 +45,8 @@ namespace Model.Reducer {
                         if (neighbourID == 25 && placeItem.itemID == 25) continue;
                         // If machine and machine, don't connect
                         if (item.isMachine() && neighbour.isMachine()) continue;
+                        // If solar and machine or machine & solar, don't connect
+                        if (neighbourID == 25 && item.isMachine() || neighbour.isMachine() && placeItem.itemID == 25) continue;
                         
                         // If solar, wire or electricity powered machine, continue
                         if (neighbourID == 25 || neighbourID == 22 || (neighbour.isMachine() && neighbour.isPoweredByElectricity())) {
@@ -54,17 +56,20 @@ namespace Model.Reducer {
                 }
 
                 // Play sound relative to the object being placed.
-                soundController.PlayPlacementSound(placeItem.itemID);
+                // TODO: FIX ME - THIS CANNOT BE HERE
+                // soundController.PlayPlacementSound(placeItem.itemID);
 
                 GameManager.Instance().machineStore.Dispatch(new UpdateConnected());
             }
         }
 
         public void visit(CollectItem collectItem) {
-            if (soundController == null)
-                soundController = GameObject.Find("SoundController").GetComponent<SoundController>();
+            // TODO: FIX ME - THIS CANNOT BE HERE
+            // if (soundController == null) {
+            //    soundController = GameObject.Find("SoundController").GetComponent<SoundController>();
+            // }
 
-            if (state.GetObjects().ContainsKey(collectItem.position)) {
+        if (state.GetObjects().ContainsKey(collectItem.position)) {
                 MapObject obj = state.GetObjects()[collectItem.position];
                
                 state.RemoveObject(collectItem.position);
@@ -72,15 +77,17 @@ namespace Model.Reducer {
                 GameManager.Instance().inventoryStore.Dispatch(new AddItemToInventory(obj.GetID(), 1));
                 GameManager.Instance().machineStore.Dispatch(new UpdateConnected());
 
+              
+                // TODO: FIX ME - THIS CANNOT BE HERE
                 // Play sound relative to the object being picked up.
-                soundController.PlayPlacementSound(obj.GetID());
+                // soundController.PlayPlacementSound(obj.GetID());
             }
         }
 
         public void visit(RotateItem rotateItem) {
             if (state.getObjects().ContainsKey(rotateItem.position)) {
                 state.RotateObject(rotateItem.position);
-                soundController.PlayButtonPressSound();
+                // soundController.PlayButtonPressSound();
             }
         }
       


### PR DESCRIPTION
Closes #102 
Requires wires to be present to connect a solar with a machine.

However, this PR also highlights a new issue, #132.
We **cannot** have game code inside the reducer, this renders the whole architecture void and untestable. I have removed the code and endeavour to fix the issue in a separate PR.